### PR TITLE
Update 3.2.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "3.2.3" %}
+{% set version = "3.2.4" %}
 
 package:
   name: xerces-c
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://archive.apache.org/dist/xerces/c/3/sources/xerces-c-{{ version }}.tar.gz
-  sha256: fb96fc49b1fb892d1e64e53a6ada8accf6f0e6d30ce0937956ec68d39bd72c7e
+  sha256: 3d8ec1c7f94e38fee0e4ca5ad1e1d9db23cbf3a10bba626f6b4afa2dedafe5ab
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,10 +26,6 @@ requirements:
   host:
     - icu   # [not win]
     - cctools  # [osx]
-test:
-  commands:
-    - conda inspect linkages -p $PREFIX $PKG_NAME  # [not win]
-    - conda inspect objects -p $PREFIX $PKG_NAME  # [osx]
 
 about:
   home: http://xerces.apache.org/xerces-c/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,14 +28,21 @@ requirements:
     - cctools  # [osx]
 
 about:
-  home: http://xerces.apache.org/xerces-c/
-  license: Apache 2.0
+  home: https://xerces.apache.org/xerces-c/
+  license: Apache-2.0
   license_family: Apache
   license_file: LICENSE
   summary: 'Xerces-C++ is a validating XML parser written in a portable subset of C++.'
+  description: |
+    Xerces-C++ makes it easy to give your application the ability to read and write XML data. A shared library is provided for parsing, generating, manipulating, and validating XML documents using the DOM, SAX, and SAX2 APIs.
+  dev_url: https://github.com/apache/xerces-c
+  doc_url: https://xerces.apache.org/xerces-c/program-3.html
 
 extra:
   recipe-maintainers:
     - gillins
     - groutr
     - ocefpaf
+  skip-lints:
+    - missing_license_url
+    - missing_doc_source_url


### PR DESCRIPTION
# Xerces-c 3.2.4

Home: https://xerces.apache.org/xerces-c/
Upstream: https://github.com/apache/xerces-c
3.2.3 vs 3.2.4 diff: https://github.com/apache/xerces-c/compare/v3.2.3...v3.2.4
Jira: https://anaconda.atlassian.net/browse/PKG-420


- Update version and SHA
- Remove tests in `meta.yaml` due to presence of `run_test.py`
- Update about section